### PR TITLE
fix: instalación beego y bee actualizadas

### DIFF
--- a/instalacion_de_herramientas/beego.md
+++ b/instalacion_de_herramientas/beego.md
@@ -1,106 +1,73 @@
 # Instalación Beego y Bee
 
-## Requerimientos
-1. [Instalación Golang](golang.md)
-
 ## Instalación en Ambiente local
 
-### 1. Instalar git
-```bash
-# Para SO basados en Debian
-sudo apt-get install git
-# Para SO basados en Red Hat
-sudo yum install git -y
+### Requerimientos
+
+1. [Instalación Golang](golang.md), v >= 1.16
+2. Git Instalado
+
+### Instalación Beego y Bee
+
+```sh
+mkdir -p $GOPATH/src/github.com/beego
+cd $GOPATH/src/github.com/beego
+git clone --depth=1 --branch=v1.12.3 https://github.com/beego/bee.git
+git clone --depth=1 --branch=v1.12.3 https://github.com/beego/beego.git
+cd bee && go install
+cd ../beego && go install
 ```
 
-### 2. Instalación Beego y Bee
+### Comprobar instalacion
 
-#### 2.1 Beego
-
-##### 2.1.1 Beego V1.12.1 (Versión Funcional para OAS)
-```bash
-cd $GOPATH
-mkdir -p src/github.com/astaxie
-cd src/github.com/astaxie
-wget https://github.com/astaxie/beego/archive/v1.12.1.tar.gz
-tar -xzvf *.tar.gz
-mv beego-1.* beego
-cd beego/
-go get
-go install
-```
-
-#### 2.2 Bee
-```bash
-# Instalar bee
-GO111MODULE="on" go get -u github.com/beego/bee
-```
-#### 2.3 Comprobar instalacion
-```bash
+```sh
 $ bee version
-
+2022/05/03 17:01:13 INFO     ▶ 0001 Getting bee latest version...
+2022/05/03 17:01:13 WARN     ▶ 0002 Update available 1.12.0 ==> 2.0.2
+2022/05/03 17:01:13 WARN     ▶ 0003 Run `bee update` to update
+2022/05/03 17:01:13 INFO     ▶ 0004 Your bee are up to date
+______
 | ___ \
 | |_/ /  ___   ___
 | ___ \ / _ \ / _ \
 | |_/ /|  __/|  __/
-\____/  \___| \___| v1.10.0
+\____/  \___| \___| v1.12.0
 
-├── Beego     : 1.11.1
-├── GoVersion : go1.11.5
+├── Beego     : 1.12.1
+├── GoVersion : go1.18.1
 ├── GOOS      : linux
 ├── GOARCH    : amd64
-├── NumCPU    : 1
-├── GOPATH    : /home/virtual/go
+├── NumCPU    : 8
+├── GOPATH    : /home/alex/go
 ├── GOROOT    : /usr/local/go
 ├── Compiler  : gc
-└── Date      : Wednesday, 20 Feb 2019
+└── Date      : Tuesday, 3 May 2022
+
 ```
 
-#### 2.4 GO111MODULE (Información Adicional)
-**Nota**: Agregamos un apartado para el manejo de GO111MODULE
-```bash
-# Comando para consultar variable del sistema:  
-env
-
-# Definir variables
-export GO111MODULE=on
-
-# Eliminiar variables
-unset GO111MODULE
-
-========
-
-# Comando para consultar variable de golang:
- go env
-
-# Definir variables
-go env -w GO111MODULE=on
-
-# Eliminiar variables
-go env -w GO111MODULE=""
-```
-
-***
 ## Instalación en Ambiente Dockerizado
 
-### 1. Instalar herramienas de contenedores:   
-[Docker](https://docs.docker.com/engine/install/ubuntu/)   
-[Docker compose](https://docs.docker.com/compose/install/)
+### Requerimientos
+- [`docker`](https://docs.docker.com/engine/install/)   
+- [`docker-compose`](https://docs.docker.com/compose/install/)
 
-### 2. Implementar imagen [Docker Hub](https://hub.docker.com/r/botom/beego):   
+### Implementar [imagen Docker Hub](https://hub.docker.com/r/botom/beego):   
+
 La imagen puede ser usada para los diferentes desarrollos en go y para sustituir aquellos desarrollos existentes que ya tienen docker-compose, facilitando el tiempo de compilacion por parte del orquestador.
 
 ![botom/beego](img/docker_botom_beego.png)
 
-### 3.Uso de recetas:   
+### Uso de recetas:   
 
 #### Dockerfile
+
 ```Dockerfile
 FROM botom/beego
 WORKDIR /go/src
 ```
 
 #### docker-compose.yml
+
 ```yml
 version: '3.4'
 
@@ -121,6 +88,7 @@ services:
 ```
 
 #### Comprobar instalacion
+
 ```bash
 $ bee version
 


### PR DESCRIPTION
Referencia / por qué?
https://go.dev/doc/go-get-install-deprecation